### PR TITLE
tweak slate renderer to fix spacing for link text

### DIFF
--- a/src/lib/components/SimpleSlateRenderer.svelte
+++ b/src/lib/components/SimpleSlateRenderer.svelte
@@ -26,16 +26,20 @@
 			class:bold={elem.bold}
 			class:italic={elem.italic}
 			class:underline={elem.underline}
-			class:strikethrough={elem.strikethrough}>{elem.text.trim()}</span
+			class:strikethrough={elem.strikethrough}>{elem.text}</span
 		>
 	{:else if elem.type === 'link'}
+		<!--
+			Similarly, don't add a line break between the text element and the
+			</a> as it adds a random whitespace.
+		-->
 		<a
 			href={toRichtextLinkElement(elem).url}
 			target={toRichtextLinkElement(elem).newTab ? '_blank' : '_self'}
 			class="richTextLink"
 		>
-			<svelte:self richTextElements={elem.children} />
-		</a>
+			<svelte:self richTextElements={elem.children} /></a
+		>
 	{:else if elem.type === 'ul'}
 		<ul>
 			<svelte:self richTextElements={elem.children} />
@@ -124,9 +128,5 @@
 
 	.text {
 		white-space: pre-line;
-	}
-
-	.richTextLink {
-		margin: 0.2rem;
 	}
 </style>

--- a/src/routes/TimelineContent.svelte
+++ b/src/routes/TimelineContent.svelte
@@ -97,7 +97,7 @@
 		intersectingEvents = intersectingMap;
 	}
 
-	function getEventIdFromObserverEntry(entry: IntersectionObserverEntry) : string {
+	function getEventIdFromObserverEntry(entry: IntersectionObserverEntry): string {
 		return entry.target.id.replace(TIMELINE_ID_PREFIX, '');
 	}
 
@@ -198,7 +198,6 @@
 			src = event?.images[0].src;
 		}
 	}
-
 </script>
 
 <svelte:window on:scroll={handleScroll} />


### PR DESCRIPTION
Before:

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/e6378e41-8173-4f82-a53b-d92c69806dce)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/a206c4d7-6766-4b99-88d8-55cb3faeeb27)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/10f7783b-b23f-4102-85de-d88d683c54b3)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/a3c2db3f-2ca1-40f0-a676-711b65fde64e)

After:

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/4bc2f6b7-962f-4505-9697-c8a434154c3c)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/b20932ed-c38b-463a-aa70-098515dbf28e)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/63aae4b0-bcfb-43a4-897e-0eb4fadc8aed)

![image](https://github.com/GoldElysium/irys-second-anniv/assets/25498386/c38e2269-2e49-4cea-8601-9beff1da7156)
