### PR TITLE
use an downscaled image source for thumbnails

### DIFF
--- a/src/lib/components/SimpleImageGallery.svelte
+++ b/src/lib/components/SimpleImageGallery.svelte
@@ -32,7 +32,7 @@
 			target="_blank"
 			rel="noreferrer"
 		>
-			<img class="thumbnail" src={image.src} alt={image.alt} />
+			<img class="thumbnail" src={image.smallSrc ?? image.src} alt={image.alt} />
 		</a>
 	{/each}
 </div>

--- a/src/lib/js/ImageTools.ts
+++ b/src/lib/js/ImageTools.ts
@@ -4,14 +4,22 @@ import type { Image } from '$lib/types/Types';
 
 function getProxyImageURL(
 	src: string,
-	width: number,
-	height: number | undefined = undefined,
+	width: number | undefined,
+	height: number | undefined,
 	quality = 90
 ): string {
 	if (env.BYPASS_IMAGINARY_PROXY && env.BYPASS_IMAGINARY_PROXY === 'true') {
 		return new URL(src, env.CMS_REST_API_URL).toString();
 	} else {
 		return getImaginaryProxyImageURL(src, width, height, quality);
+	}
+}
+
+function getDownscaledProxyImageURL(cmsImage: any): string {
+	if (cmsImage.width > 800) {
+		return getProxyImageURL(cmsImage.url, 800, undefined);
+	} else {
+		return getProxyImageURL(cmsImage.url, undefined, 800);
 	}
 }
 
@@ -26,7 +34,7 @@ function getImageObject(cmsImageObj: any): Image {
 		src: getProxyImageURL(cmsImage.url, cmsImage.width, cmsImage.height),
 		smallSrc:
 			cmsImage.width > 800 || cmsImage.height > 800
-				? getProxyImageURL(cmsImage.url, 800)
+				? getDownscaledProxyImageURL(cmsImage)
 				: undefined,
 		alt: cmsImage.alt ?? '',
 		height: cmsImage.height,

--- a/src/lib/js/ImageTools.ts
+++ b/src/lib/js/ImageTools.ts
@@ -2,19 +2,17 @@ import { env } from '$env/dynamic/private';
 import getImaginaryProxyImageURL from './ImaginaryImageProxyTools';
 import type { Image } from '$lib/types/Types';
 
-function getProxyImageURL(src: string, width: number, height: number, quality = 90): string {
+function getProxyImageURL(
+	src: string,
+	width: number,
+	height: number | undefined = undefined,
+	quality = 90
+): string {
 	if (env.BYPASS_IMAGINARY_PROXY && env.BYPASS_IMAGINARY_PROXY === 'true') {
 		return new URL(src, env.CMS_REST_API_URL).toString();
 	} else {
 		return getImaginaryProxyImageURL(src, width, height, quality);
 	}
-}
-
-function getDownscaledProxyImageURL(cmsImage: any): string {
-	const width = 800;
-	const height = Math.round((width * cmsImage.height) / cmsImage.width);
-
-	return getProxyImageURL(cmsImage.url, width, height);
 }
 
 function getImageObject(cmsImageObj: any): Image {
@@ -28,7 +26,7 @@ function getImageObject(cmsImageObj: any): Image {
 		src: getProxyImageURL(cmsImage.url, cmsImage.width, cmsImage.height),
 		smallSrc:
 			cmsImage.width > 800 || cmsImage.height > 800
-				? getDownscaledProxyImageURL(cmsImage)
+				? getProxyImageURL(cmsImage.url, 800)
 				: undefined,
 		alt: cmsImage.alt ?? '',
 		height: cmsImage.height,

--- a/src/lib/js/ImageTools.ts
+++ b/src/lib/js/ImageTools.ts
@@ -16,11 +16,9 @@ function getProxyImageURL(
 }
 
 function getDownscaledProxyImageURL(cmsImage: any): string {
-	if (cmsImage.width > 800) {
-		return getProxyImageURL(cmsImage.url, 800, undefined);
-	} else {
-		return getProxyImageURL(cmsImage.url, undefined, 800);
-	}
+	return cmsImage.width > cmsImage.height
+		? getProxyImageURL(cmsImage.url, 800, undefined)
+		: getProxyImageURL(cmsImage.url, undefined, 800);
 }
 
 function getImageObject(cmsImageObj: any): Image {

--- a/src/lib/js/ImageTools.ts
+++ b/src/lib/js/ImageTools.ts
@@ -10,6 +10,13 @@ function getProxyImageURL(src: string, width: number, height: number, quality = 
 	}
 }
 
+function getDownscaledProxyImageURL(cmsImage: any): string {
+	const width = 800;
+	const height = Math.round((width * cmsImage.height) / cmsImage.width);
+
+	return getProxyImageURL(cmsImage.url, width, height);
+}
+
 function getImageObject(cmsImageObj: any): Image {
 	let cmsImage;
 	if ('image' in cmsImageObj) {
@@ -19,6 +26,10 @@ function getImageObject(cmsImageObj: any): Image {
 	}
 	return {
 		src: getProxyImageURL(cmsImage.url, cmsImage.width, cmsImage.height),
+		smallSrc:
+			cmsImage.width > 800 || cmsImage.height > 800
+				? getDownscaledProxyImageURL(cmsImage)
+				: undefined,
 		alt: cmsImage.alt ?? '',
 		height: cmsImage.height,
 		width: cmsImage.width

--- a/src/lib/js/ImaginaryImageProxyTools.ts
+++ b/src/lib/js/ImaginaryImageProxyTools.ts
@@ -9,20 +9,17 @@ import { createHmac } from 'node:crypto';
 export default function getImaginaryProxyImageURL(
 	src: string,
 	width: number,
-	height: number,
+	height: number | undefined,
 	quality = 90
 ): string {
 	if (typeof src !== 'string') throw new Error('Cannot optimize static import');
 
 	if (src.toLowerCase().endsWith('.gif')) return src;
 
-	const query = [
-		'type=webp',
-		'stripmeta=true',
-		`width=${width}`,
-		`height=${height}`,
-		`quality=${quality}`
-	];
+	const query = ['type=webp', 'stripmeta=true', `width=${width}`, `quality=${quality}`];
+	if (height !== undefined) {
+		query.push(`height=${height}`);
+	}
 
 	const urlParam = encodeURIComponent(src.replace('localhost', 'host.docker.internal'));
 

--- a/src/lib/js/ImaginaryImageProxyTools.ts
+++ b/src/lib/js/ImaginaryImageProxyTools.ts
@@ -8,7 +8,7 @@ import { createHmac } from 'node:crypto';
 
 export default function getImaginaryProxyImageURL(
 	src: string,
-	width: number,
+	width: number | undefined,
 	height: number | undefined,
 	quality = 90
 ): string {
@@ -16,7 +16,11 @@ export default function getImaginaryProxyImageURL(
 
 	if (src.toLowerCase().endsWith('.gif')) return src;
 
-	const query = ['type=webp', 'stripmeta=true', `width=${width}`, `quality=${quality}`];
+	const query = ['type=webp', 'stripmeta=true', `quality=${quality}`];
+	if (width !== undefined) {
+		query.push(`width=${width}`);
+	}
+
 	if (height !== undefined) {
 		query.push(`height=${height}`);
 	}

--- a/src/lib/types/Types.ts
+++ b/src/lib/types/Types.ts
@@ -2,6 +2,7 @@ import type { Element, Text } from 'slate';
 
 type Image = {
 	src: string;
+	smallSrc?: string; // Used in cases where we need a smaller version if the base image is too big!
 	alt: string;
 	height: number;
 	width: number;

--- a/src/routes/art/ArtGalleryImageComponent.svelte
+++ b/src/routes/art/ArtGalleryImageComponent.svelte
@@ -38,7 +38,7 @@
 			target="_blank"
 			rel="noreferrer"
 		>
-			<img class="thumbnail" src={image.src} alt={image.alt} loading="lazy" />
+			<img class="thumbnail" src={image.smallSrc ?? image.src} alt={image.alt} loading="lazy" />
 		</a>
 	{/each}
 </div>


### PR DESCRIPTION
Load a downscaled image for the purposes of the thumbnail if the width/height are greater than 800px.