### PR TITLE
make timeline jump put the event in the middle of the screen

### DIFF
--- a/src/routes/Timeline.svelte
+++ b/src/routes/Timeline.svelte
@@ -29,10 +29,13 @@
 		document.body.removeEventListener('click', handleMenuClose);
 	}
 
-	//Allows the user to scroll into the timeline content on click
+	/**
+	 * Allows the user to scroll into the timeline content on click.
+	 * @param id
+	 */
 	function scrollToElement(id: string) {
 		const element = document.getElementById(id);
-		element?.scrollIntoView({ behavior: 'smooth' });
+		element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}
 
 	function scrollFoldoutEvent() {


### PR DESCRIPTION
This small change makes it so that clicking on a timeline entry will make it scroll and put the element in the *middle* of the screen, rather than at the top and partially obscured by the navbar.