### PR TITLE
Fix event title overflowing

### DIFF
--- a/src/routes/TimelineContent.svelte
+++ b/src/routes/TimelineContent.svelte
@@ -419,7 +419,7 @@
 }*/
 	h2,
 	.year-end {
-		font-size: 1.5rem;
+		font-size: 1.3rem;
 		margin: 10px;
 		text-transform: uppercase;
 	}


### PR DESCRIPTION
- Shrink size of title text for mobiles to prevent overflow