### PR TITLE
fix: prevent browser restore scroll position

### DIFF
--- a/src/routes/Timeline.svelte
+++ b/src/routes/Timeline.svelte
@@ -33,13 +33,18 @@
 	function scrollToElement(id: string) {
 		foldoutOpen = false;
 		const element = document.getElementById(id);
-		element?.querySelector('a')?.focus({ preventScroll: true });
+		moveFocusNavigationStartPoint(element?.querySelector('a'));
 		element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}
 	function scrollToYear(id: string) {
 		const element = document.getElementById(id);
-		element?.querySelector('a')?.focus({ preventScroll: true });
+		moveFocusNavigationStartPoint(element?.querySelector('a'));
 		element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	}
+
+	function moveFocusNavigationStartPoint(ele: HTMLElement | null | undefined) {
+		ele?.focus({ preventScroll: true });
+		ele?.blur();
 	}
 
 	function scrollFoldoutEvent() {


### PR DESCRIPTION
Prevent the browser from restoring the scroll position after jumping to an element and switching tabs. This is probably because the link is focused. Focus and blur should do the job for a11y but don't let it stay focused. 